### PR TITLE
feat: 重构肉墙实体远距离渲染系统

### DIFF
--- a/src/main/java/org/confluence/terraentity/client/event/RenderEvent.java
+++ b/src/main/java/org/confluence/terraentity/client/event/RenderEvent.java
@@ -31,11 +31,14 @@ import org.confluence.terraentity.client.post.BrainTranslucent;
 import org.confluence.terraentity.client.post.TongueRenderer;
 import org.confluence.terraentity.client.post.WallOfFleshTranslucent;
 import org.confluence.terraentity.entity.boss.wallofflesh.WallOfFlesh;
+import org.confluence.terraentity.init.entity.TEBossEntities;
 import org.confluence.terraentity.network.s2c.SyncWallOfFleshEntitiesPacket;
 import org.confluence.terraentity.integration.ModChecker;
 import org.confluence.terraentity.item.BaseWhipItem;
 import org.confluence.terraentity.item.YoyosItem;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.confluence.terraentity.TerraEntity.MODID;
@@ -66,22 +69,17 @@ public class RenderEvent {
 
     public static boolean isIrisShader = false;
     public static boolean isAfterSky = false;
+
+    // 静态的虚拟实体，用于渲染远处的肉山
+    private static WallOfFlesh dummyBoss;
+
     @SubscribeEvent
     public static void renderLevelStage(RenderLevelStageEvent event) {
         if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_LEVEL) {
             BrainTranslucent.render(event);
             WallOfFleshTranslucent.render(event);
             DebugBlocksHelper.Singleton().render(event);
-            //            NPCRenderer.target.blitToScreen(100,100);
             NPCChatBubbleBuffer.getInstance().render(event);
-//            if (!VeilLevelPerspectiveRenderer.isRenderingPerspective()) {
-//                if (VeilRenderSystem.drawLights(Minecraft.getInstance().level.getProfiler(), VeilRenderSystem.getCullingFrustum())) {
-//                    VeilRenderSystem.compositeLights(Minecraft.getInstance().level.getProfiler());
-//                } else {
-//                    AdvancedFbo.unbind();
-//                }
-//            }
-
             isAfterSky = false;
         } else if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS) {
             TongueRenderer.renderFirstPerson(event);
@@ -99,30 +97,70 @@ public class RenderEvent {
                 Vec3 cameraPos = event.getCamera().getPosition();
                 poseStack.translate(-cameraPos.x, -cameraPos.y, -cameraPos.z);
 
-                // 使用从服务端同步的肉墙实体ID列表
-                Set<Integer> syncedIds = SyncWallOfFleshEntitiesPacket.getClientWallOfFleshIds();
-                Set<Integer> renderedIds = new java.util.HashSet<>(); // 记录已渲染的实体ID，避免重复渲染
-                
-                // 先尝试使用同步的实体ID列表进行渲染
-                if (!syncedIds.isEmpty()) {
-                    for (Integer id : syncedIds) {
-                        Entity entity = level.getEntity(id);
-                        if (entity instanceof WallOfFlesh wall) {
-                            var renderer = mc.getEntityRenderDispatcher().getRenderer(wall);
+                // 获取包含坐标信息的列表
+                List<SyncWallOfFleshEntitiesPacket.BossInfo> infos = SyncWallOfFleshEntitiesPacket.getClientBossInfos();
+                Set<Integer> renderedIds = new HashSet<>();
+
+                if (!infos.isEmpty()) {
+
+                    for (SyncWallOfFleshEntitiesPacket.BossInfo info : infos) {
+
+                        if (info.dimension() != level.dimension()) {
+                            continue;
+                        }
+
+                        Entity realEntity = level.getEntity(info.id());
+                        WallOfFlesh entityToRender = null;
+
+                        // 1. 如果客户端能找到真实的实体，直接用真实的
+                        if (realEntity instanceof WallOfFlesh wall) {
+                            entityToRender = wall;
+                        }
+                        // 2. 如果找不到（太远了），使用虚拟实体
+                        else {
+                            if (dummyBoss == null || dummyBoss.level() != level) {
+                                dummyBoss = new WallOfFlesh(TEBossEntities.WALL_OF_FLESH.get(), level);
+                            }
+                            // 将虚拟实体移动到数据包指定的位置
+                            dummyBoss.setPos(info.x(), info.y(), info.z());
+
+                            float rot = info.yRot();
+                            // 设置当前旋转
+                            dummyBoss.setYRot(rot);
+                            dummyBoss.yBodyRot = rot;
+                            dummyBoss.yHeadRot = rot;
+                            // 强制设置"上一帧"的旋转等于当前旋转-避免在视距边缘由于频繁切换实体渲染和虚拟渲染导致的旋转问题
+                            dummyBoss.yRotO = rot;
+                            dummyBoss.yBodyRotO = rot;
+                            dummyBoss.yHeadRotO = rot;
+
+                            dummyBoss.setId(info.id());
+                            entityToRender = dummyBoss;
+                        }
+
+                        if (entityToRender != null) {
+                            var renderer = mc.getEntityRenderDispatcher().getRenderer(entityToRender);
                             if (renderer instanceof WallOfFleshRenderer wallRenderer) {
                                 poseStack.pushPose();
-                                poseStack.translate(wall.getX(), wall.getY(), wall.getZ());
-                                float entityYaw = wall.getYRot();
-                                int packedLight = mc.getEntityRenderDispatcher().getPackedLightCoords(wall, partialTick);
-                                wallRenderer.renderToTarget(wall, entityYaw, partialTick, poseStack, bufferSource, packedLight);
+                                // 移动到目标位置 (info.x/y/z 是最新的服务端位置)
+                                poseStack.translate(info.x(), info.y(), info.z());
+
+                                // 渲染。注意：最后一个参数是光照。对于远处的 Boss，建议给满亮度 (15728880)，否则可能因为区块没加载而全黑
+                                wallRenderer.renderToTarget(
+                                        entityToRender,
+                                        info.yRot(),
+                                        partialTick,
+                                        poseStack,
+                                        bufferSource,
+                                        15728880);
                                 poseStack.popPose();
-                                renderedIds.add(wall.getId());
+                                renderedIds.add(info.id());
                             }
                         }
                     }
                 }
-                
-                // 遍历所有实体，渲染那些已加载但可能不在同步列表中的实体（或同步列表为空时）
+
+                // 3. 渲染原本就在附近的实体（防止闪烁或遗漏，但跳过已经渲染过的 ID）
                 for (Entity entity : level.getEntities().getAll()) {
                     if (entity instanceof WallOfFlesh wall && !renderedIds.contains(wall.getId())) {
                         var renderer = mc.getEntityRenderDispatcher().getRenderer(wall);
@@ -131,20 +169,18 @@ public class RenderEvent {
                             poseStack.translate(wall.getX(), wall.getY(), wall.getZ());
                             float entityYaw = wall.getYRot();
                             int packedLight = mc.getEntityRenderDispatcher().getPackedLightCoords(wall, partialTick);
-                            wallRenderer.renderToTarget(wall, entityYaw, partialTick, poseStack, bufferSource, packedLight);
+                            wallRenderer.renderToTarget(wall, entityYaw, partialTick, poseStack, bufferSource,
+                                    packedLight);
                             poseStack.popPose();
                         }
                     }
                 }
-
                 bufferSource.endBatch();
                 poseStack.popPose();
             }
         } else if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_SKY) {
-//            NPCChatBubbleBuffer.getInstance().refresh();
-
             isAfterSky = true;
-        } else if(event.getStage() == RenderLevelStageEvent.Stage.AFTER_ENTITIES){
+        } else if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_ENTITIES) {
             isIrisShader = ModChecker.iris.isLoaded() && RenderSystem.getShader() instanceof ExtendedShader;
             DebugEntityHelper.INSTANCE.render(event);
         }

--- a/src/main/java/org/confluence/terraentity/event/ServerTickEvent.java
+++ b/src/main/java/org/confluence/terraentity/event/ServerTickEvent.java
@@ -19,30 +19,29 @@ import java.util.List;
 @EventBusSubscriber(modid = TerraEntity.MODID)
 public class ServerTickEvent {
 
-    private static final int SYNC_INTERVAL = 20; // 每20tick（1秒）同步一次
-
     @SubscribeEvent
     public static void onLevelTick(LevelTickEvent.Post event) {
-        if (!(event.getLevel() instanceof ServerLevel serverLevel)) {
+        if (!(event.getLevel() instanceof ServerLevel serverLevel))
             return;
-        }
+        serverLevel.getGameTime();
 
-        // 每SYNC_INTERVAL tick同步一次
-        if (serverLevel.getGameTime() % SYNC_INTERVAL != 0) {
-            return;
-        }
+        List<SyncWallOfFleshEntitiesPacket.BossInfo> infos = new ArrayList<>();
 
-        // 收集所有肉墙实体
-        List<Integer> wallOfFleshIds = new ArrayList<>();
+        // 收集发送肉墙实体数据
         for (Entity entity : serverLevel.getEntities().getAll()) {
             if (entity instanceof WallOfFlesh && entity.isAlive()) {
-                wallOfFleshIds.add(entity.getId());
+                infos.add(new SyncWallOfFleshEntitiesPacket.BossInfo(
+                        entity.getId(),
+                        entity.getX(),
+                        entity.getY(),
+                        entity.getZ(),
+                        entity.getYRot(),
+                        entity.level().dimension()));
             }
         }
 
-        // 如果有肉墙实体，发送给所有玩家
-        if (!wallOfFleshIds.isEmpty()) {
-            SyncWallOfFleshEntitiesPacket.sendToAllPlayers(wallOfFleshIds);
+        if (!infos.isEmpty()) {
+            SyncWallOfFleshEntitiesPacket.sendToAllPlayers(infos);
         }
     }
 }

--- a/src/main/java/org/confluence/terraentity/network/NetworkHandler.java
+++ b/src/main/java/org/confluence/terraentity/network/NetworkHandler.java
@@ -24,7 +24,7 @@ public final class NetworkHandler {
         registrar.playToClient(SyncLevelNamePacketS2C.TYPE, SyncLevelNamePacketS2C.STREAM_CODEC, SyncLevelNamePacketS2C::handle);
         registrar.playToClient(SetAnglerDialogPacketS2C.TYPE, SetAnglerDialogPacketS2C.STREAM_CODEC, SetAnglerDialogPacketS2C::handle);
         registrar.playToClient(SyncWallOfFleshTargetPacket.TYPE, SyncWallOfFleshTargetPacket.STREAM_CODEC, SyncWallOfFleshTargetPacket::handle);
-
+        registrar.playToClient(SyncWallOfFleshEntitiesPacket.TYPE, SyncWallOfFleshEntitiesPacket.STREAM_CODEC, SyncWallOfFleshEntitiesPacket::handle);
 
         registrar.playToServer(ServerBoundVehicleExtensionPacket.TYPE, ServerBoundVehicleExtensionPacket.STREAM_CODEC, ServerBoundVehicleExtensionPacket::handle);
         registrar.playToServer(ServerBoundHousePacket.TYPE, ServerBoundHousePacket.STREAM_CODEC, ServerBoundHousePacket::handle);

--- a/src/main/java/org/confluence/terraentity/network/s2c/SyncWallOfFleshEntitiesPacket.java
+++ b/src/main/java/org/confluence/terraentity/network/s2c/SyncWallOfFleshEntitiesPacket.java
@@ -1,91 +1,85 @@
 package org.confluence.terraentity.network.s2c;
 
+import io.netty.buffer.ByteBuf;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 import org.confluence.terraentity.TerraEntity;
 import org.confluence.terraentity.utils.AdapterUtils;
-import org.jetbrains.annotations.NotNull;
+import net.minecraft.world.level.Level;
 
-import java.util.*;
-import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
-/**
- * 同步服务端的肉墙实体ID列表到客户端
- */
 public class SyncWallOfFleshEntitiesPacket implements CustomPacketPayload {
     public static final Type<SyncWallOfFleshEntitiesPacket> TYPE = new Type<>(
-            ResourceLocation.fromNamespaceAndPath(TerraEntity.MODID, "sync_wall_of_flesh_entities")
-    );
-    
-    // 客户端存储的肉墙实体ID集合（线程安全）
-    private static final Set<Integer> CLIENT_WALL_OF_FLESH_IDS = new CopyOnWriteArraySet<>();
-    
-    private final List<Integer> wallOfFleshIds;  // 肉墙实体ID列表
-    
-    /**
-     * 获取客户端已知的肉墙实体ID集合
-     * @return 实体ID集合的不可变视图
-     */
-    public static Set<Integer> getClientWallOfFleshIds() {
-        return Collections.unmodifiableSet(CLIENT_WALL_OF_FLESH_IDS);
+            ResourceLocation.fromNamespaceAndPath(TerraEntity.MODID, "sync_wall_of_flesh_entities"));
+
+    // 数据结构：包含ID、位置、朝向
+    public record BossInfo(
+        int id,
+        double x, double y, double z, float yRot,
+        ResourceKey<Level> dimension) {
     }
 
-    public SyncWallOfFleshEntitiesPacket(List<Integer> wallOfFleshIds) {
-        this.wallOfFleshIds = new ArrayList<>(wallOfFleshIds);
+    // 客户端存储的肉山信息列表
+    private static final List<BossInfo> CLIENT_BOSS_INFOS = new CopyOnWriteArrayList<>();
+
+    private final List<BossInfo> bossInfos;
+
+    public static List<BossInfo> getClientBossInfos() {
+        return Collections.unmodifiableList(CLIENT_BOSS_INFOS);
     }
 
-    public SyncWallOfFleshEntitiesPacket(FriendlyByteBuf buf) {
-        int count = buf.readVarInt();
-        this.wallOfFleshIds = new ArrayList<>(count);
-        for (int i = 0; i < count; i++) {
-            this.wallOfFleshIds.add(buf.readInt());
-        }
+    public SyncWallOfFleshEntitiesPacket(List<BossInfo> bossInfos) {
+        this.bossInfos = bossInfos;
     }
 
-    public void write(FriendlyByteBuf buf) {
-        buf.writeVarInt(wallOfFleshIds.size());
-        for (Integer id : wallOfFleshIds) {
-            buf.writeInt(id);
-        }
-    }
+    // 定义 BossInfo 的编解码器
+    private static final StreamCodec<ByteBuf, BossInfo> BOSS_INFO_CODEC = StreamCodec.composite(
+            ByteBufCodecs.VAR_INT, BossInfo::id,
+            ByteBufCodecs.DOUBLE, BossInfo::x,
+            ByteBufCodecs.DOUBLE, BossInfo::y,
+            ByteBufCodecs.DOUBLE, BossInfo::z,
+            ByteBufCodecs.FLOAT, BossInfo::yRot,
+            ResourceKey.streamCodec(Registries.DIMENSION), BossInfo::dimension,
+            BossInfo::new);
 
-    public static final StreamCodec<FriendlyByteBuf, SyncWallOfFleshEntitiesPacket> STREAM_CODEC = 
-        StreamCodec.of(
-            (buf, packet) -> packet.write(buf),
-            SyncWallOfFleshEntitiesPacket::new
-        );
+    public static final StreamCodec<FriendlyByteBuf, SyncWallOfFleshEntitiesPacket> STREAM_CODEC = StreamCodec
+            .composite(
+                    BOSS_INFO_CODEC.apply(ByteBufCodecs.list()),
+                    SyncWallOfFleshEntitiesPacket::bossInfos,
+                    SyncWallOfFleshEntitiesPacket::new);
+
+    public static void clear() {
+        CLIENT_BOSS_INFOS.clear();
+    }
 
     @Override
-    public @NotNull Type<? extends CustomPacketPayload> type() {
+    public Type<? extends CustomPacketPayload> type() {
         return TYPE;
+    }
+
+    public List<BossInfo> bossInfos() {
+        return bossInfos;
     }
 
     public static void handle(SyncWallOfFleshEntitiesPacket packet, IPayloadContext context) {
         context.enqueueWork(() -> {
-            // 客户端处理：直接更新静态集合
             if (context.player().level().isClientSide()) {
-                CLIENT_WALL_OF_FLESH_IDS.clear();
-                CLIENT_WALL_OF_FLESH_IDS.addAll(packet.wallOfFleshIds);
+                CLIENT_BOSS_INFOS.clear();
+                CLIENT_BOSS_INFOS.addAll(packet.bossInfos);
             }
         });
     }
 
-    /**
-     * 发送给指定玩家
-     */
-    public static void sendToPlayer(ServerPlayer player, List<Integer> wallOfFleshIds) {
-        AdapterUtils.sendToPlayer(player, new SyncWallOfFleshEntitiesPacket(wallOfFleshIds));
-    }
-
-    /**
-     * 发送给所有玩家
-     */
-    public static void sendToAllPlayers(List<Integer> wallOfFleshIds) {
-        AdapterUtils.sendToAllPlayers(new SyncWallOfFleshEntitiesPacket(wallOfFleshIds));
+    public static void sendToAllPlayers(List<BossInfo> bossInfos) {
+        AdapterUtils.sendToAllPlayers(new SyncWallOfFleshEntitiesPacket(bossInfos));
     }
 }
-


### PR DESCRIPTION
## 服务端改动 (ServerTickEvent.java)
- 移除固定的 SYNC_INTERVAL 常量, 改为每tick更新, 保证渲染动画连贯性
- 优化同步逻辑：从仅发送实体ID改为发送完整的BossInfo数据
- BossInfo包含：实体ID、坐标(x,y,z)、旋转角度(yRot)、维度信息

## 网络数据包改动 (SyncWallOfFleshEntitiesPacket.java)
- 新增 BossInfo record 类型，包含完整的实体渲染所需数据
- 重构数据包结构：从 List<Integer> 改为 List<BossInfo>
- 添加 BOSS_INFO_CODEC 编解码器支持复杂数据类型传输
- 更新客户端缓存：CLIENT_WALL_OF_FLESH_IDS 改为 CLIENT_BOSS_INFOS

## 网络注册 (NetworkHandler.java)
- 注册 SyncWallOfFleshEntitiesPacket 到客户端处理器

## 客户端渲染改动 (RenderEvent.java)
- 添加静态虚拟实体 dummyBoss 用于远距离渲染
- 实现三层渲染策略：
  1. 优先使用客户端已加载的真实实体
  2. 对于超出加载范围的实体，使用虚拟实体+服务端坐标
  3. 渲染本地已加载但未在同步列表中的实体（防止闪烁）
- 修复旋转同步问题：同步 yRot, yBodyRot, yHeadRot 及其历史值
- 为远距离虚拟实体设置固定光照值(15728880)，避免未加载区块导致的黑暗问题
- 添加维度检查，确保只渲染当前维度的实体
- 使用 renderedIds 集合避免重复渲染